### PR TITLE
Add multi-frame analysis XHTML

### DIFF
--- a/dugin-multi-frame-analysis-v2.html
+++ b/dugin-multi-frame-analysis-v2.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Dugin Multi Frame Analysis V2</title>
+  <!-- Created new analysis section, meta-dialogues, and reflection tools -->
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@300;700&family=Inconsolata&display=swap" rel="stylesheet" />
+  <style>
+    body {
+      font-family: 'Merriweather', serif;
+      margin: 0;
+      padding: 2rem;
+      background: #f5f5f5;
+      color: #222;
+      line-height: 1.6;
+    }
+    header, footer {
+      text-align: center;
+      margin-bottom: 2rem;
+    }
+    h1 {
+      font-size: 2.2rem;
+      margin-bottom: 0.2rem;
+    }
+    h2 {
+      font-size: 1.5rem;
+      margin-top: 2.5rem;
+      color: #444;
+    }
+    summary {
+      cursor: pointer;
+      font-weight: bold;
+    }
+    details {
+      background: #fff;
+      padding: 1rem;
+      border-radius: 8px;
+      margin: 1rem 0;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    aside {
+      background: #eef5ff;
+      border-left: 4px solid #5085a5;
+      padding: 1rem;
+      margin: 1rem 0;
+      font-size: 0.9rem;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 1rem 0;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 0.5rem;
+      text-align: left;
+    }
+    th {
+      background: #f0f0f0;
+    }
+    .bias-list label {
+      display: block;
+      margin: 0.4rem 0;
+    }
+    .dialogue {
+      font-family: 'Inconsolata', monospace;
+      background: #fff8e1;
+      padding: 1rem;
+      border-radius: 8px;
+      margin: 1rem 0;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Dugin Multi Frame Analysis V2</h1>
+    <p>An exploration across philosophical lenses</p>
+  </header>
+  <main>
+    <!-- Introductory outline -->
+    <section>
+      <h2>Overview</h2>
+      <p>Alexander Dugin's <em>Fourth Political Theory</em> (FPT) seeks a post-liberal paradigm, challenging modern assumptions about history, identity, and power. This document juxtaposes the FPT with frameworks from Kantian ethics, Socratic inquiry, and Buddhist mindfulness. Additional contrasts with Nietzsche's perspectivism and Laozi's Taoist philosophy invite deeper reflection.</p>
+    </section>
+
+    <!-- Comparative Table Section -->
+    <section>
+      <h2>Framework Comparison</h2>
+      <table aria-label="Comparative analysis table">
+        <thead>
+          <tr>
+            <th>Perspective</th>
+            <th>Key Idea</th>
+            <th>Dugin Alignment</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Kantian</td>
+            <td>Autonomy and moral law derived from reason</td>
+            <td>Challenges FPT's emphasis on collective identity over individual duty</td>
+          </tr>
+          <tr>
+            <td>Socratic</td>
+            <td>Dialogue as a path to self-knowledge</td>
+            <td>Dugin encourages civilizational dialogue but often from a meta-political stance</td>
+          </tr>
+          <tr>
+            <td>Buddhist</td>
+            <td>Impermanence and non-attachment</td>
+            <td>Provides a counterpoint to FPT's focus on rooted tradition</td>
+          </tr>
+          <tr>
+            <td>Nietzschean</td>
+            <td>Perspectivism and will to power</td>
+            <td>Resonates with FPT's call to revalue modernity, yet diverges on metaphysics</td>
+          </tr>
+          <tr>
+            <td>Taoist</td>
+            <td>Wu wei (effortless action)</td>
+            <td>Contrasts with FPT's active geopolitical project</td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+
+    <!-- Meta-dialogues section -->
+    <section>
+      <h2>Meta-Dialogues: Imaginary Debate Snippets</h2>
+      <div class="dialogue" role="dialog" aria-label="Dugin converses with Kant">
+        <p><strong>Dugin:</strong> "The individual must yield to the civilizational whole."</p>
+        <p><strong>Kant:</strong> "Yet without individual autonomy, no moral law can stand."</p>
+      </div>
+      <div class="dialogue" role="dialog" aria-label="Dugin converses with the Buddha">
+        <p><strong>Dugin:</strong> "History demands rooted tradition."</p>
+        <p><strong>Buddha:</strong> "Grasping at roots binds us to suffering. Release yields clarity."</p>
+      </div>
+      <div class="dialogue" role="dialog" aria-label="Dugin converses with Nietzsche">
+        <p><strong>Dugin:</strong> "A new political theory must overturn liberal modernity."</p>
+        <p><strong>Nietzsche:</strong> "Only the overcomer who transcends all systems truly creates values."</p>
+      </div>
+    </section>
+
+    <!-- Cognitive Bias checklist -->
+    <section>
+      <h2>Cognitive Bias Checklist</h2>
+      <form class="bias-list" aria-label="Checklist for personal reflection">
+        <label><input type="checkbox" /> Confirmation Bias</label>
+        <label><input type="checkbox" /> In-group Bias</label>
+        <label><input type="checkbox" /> Authority Bias</label>
+        <label><input type="checkbox" /> Availability Heuristic</label>
+        <label><input type="checkbox" /> Fundamental Attribution Error</label>
+      </form>
+      <p>Consider how these biases might color your reading of Dugin and his critics.</p>
+    </section>
+
+    <!-- Reflective exercise with details -->
+    <section>
+      <h2>Self-Experimentation Prompts</h2>
+      <details>
+        <summary>Frame-Switching Exercise</summary>
+        <p>Describe a current political issue from the standpoint of FPT. Then reinterpret the same issue through Kantian ethics. How does the focus shift?</p>
+      </details>
+      <details>
+        <summary>Mindfulness Reflection</summary>
+        <p>Set a five-minute timer. Observe any emotional reactions to the material without judgment. Note which ideas trigger attachment or aversion.</p>
+      </details>
+    </section>
+
+    <!-- Micro-reflection notes -->
+    <section>
+      <h2>Micro-Reflections</h2>
+      <aside>Notice the rhetorical move when FPT rejects liberal universalism: it reframes history as multipolar. Do you resist or resonate with this shift?</aside>
+      <aside>When Nietzsche mocks herd morality, does it illuminate or obscure Dugin's call for geopolitical destiny?</aside>
+    </section>
+
+    <!-- SVG diagram for visual learners -->
+    <section>
+      <h2>Conceptual Diagram</h2>
+      <figure>
+        <svg width="100%" height="200" viewBox="0 0 600 200" xmlns="http://www.w3.org/2000/svg" aria-labelledby="diagramTitle">
+          <title id="diagramTitle">Relationship of Philosophical Frames</title>
+          <circle cx="150" cy="100" r="60" fill="#d8e8f8" />
+          <circle cx="300" cy="100" r="60" fill="#f8d8e8" />
+          <circle cx="450" cy="100" r="60" fill="#e8f8d8" />
+          <text x="150" y="105" text-anchor="middle" font-size="14">Kant</text>
+          <text x="300" y="105" text-anchor="middle" font-size="14">Dugin</text>
+          <text x="450" y="105" text-anchor="middle" font-size="14">Buddha</text>
+        </svg>
+        <figcaption>Intersections hint at areas of potential synthesis.</figcaption>
+      </figure>
+    </section>
+  </main>
+  <footer>
+    &copy; 2025—2060 Collaborative Philosophical Project
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- start new XHTML file `Dugin Multi Frame Analysis V2`
- compare Dugin to Kant, Socratic, Buddhist, Nietzschean and Taoist frames
- add interactive meta-dialogues, bias checklist and reflective prompts
- provide conceptual diagram for synthesis

## Testing
- `git status --short`
